### PR TITLE
Fix the bug for extreme case in Gilbert

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install
 =======
 Create a [conda](http://conda.pydata.org/docs/install/quick.html) environment for calour:
 ```
-conda create -n dsfdr python=3.5 numpy scipy jupyter scikit-learn statsmodels
+conda create -n dsfdr python=3.5 numpy scipy jupyter scikit-learn scikit-bio statsmodels
 ```
 
 and activate it using:

--- a/dsfdr/dsfdr.py
+++ b/dsfdr/dsfdr.py
@@ -146,10 +146,6 @@ def dsfdr(data, labels, transform_type='rankdata', method='meandiff',
         raise ValueError('transform type %s not supported' % transform_type)
 
     numbact = np.shape(data)[0]
-
-    labels = labels.copy()
-
-    numbact = np.shape(data)[0]
     labels = labels.copy()
 
     if method == 'meandiff':

--- a/dsfdr/dsfdr.py
+++ b/dsfdr/dsfdr.py
@@ -107,8 +107,7 @@ def dsfdr(data, labels, transform_type='rankdata', method='meandiff',
             rdat = np.sort(data[i,:])[::-1] # sort in decending order
 
             s1, p1 = scipy.stats.kruskal(cdat[:n0],cdat[n0:])
-            #s2, p2 = scipy.stats.kruskal(rdat[:n0],rdat[n0:])
-            s2, p2 = scipy.stats.kruskal(cdat[:n1],cdat[n1:])
+            s2, p2 = scipy.stats.kruskal(rdat[:n0],rdat[n0:])
 
             alpha_star.append(np.min([p1,p2]))
         # find the smallest K which is big enough for Bonferoni (that's how it's done in Gilbert)


### PR DESCRIPTION
When Gilbert filters out all the hypotheses, set resulting p-value to be 1 and reject none.